### PR TITLE
feat: transform `ESM` to `CommonJS`

### DIFF
--- a/embed.js
+++ b/embed.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { readFileSync, writeFileSync } from 'fs';
+const { readFileSync, writeFileSync } = require('fs');
 
 const script =
     process.argv[2] === 'minify'

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "author": "Microsoft",
   "license": "MIT",
-  "type": "module",
+  "type": "commonjs",
   "main": "index.js",
   "typings": "index.d.ts",
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "es2020",
-        "module": "node16",
+        "module": "CommonJS",
         "sourceMap": true,
         "declaration": true,
         "strict": true,


### PR DESCRIPTION
First of all, thank you for your library! Given usefulness of your library, do you mind converting to CommonJS for now until JS community finally makes it to ESM world? It should not break `ESM` users.